### PR TITLE
Add Backward Compatibility

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-tuple "0.2.1"
+(defproject clj-tuple "0.2.2-SNAPSHOT"
   :description "Efficient small collections."
   :license {:name "MIT License"
             :url "http://opensource.org/licenses/MIT"}

--- a/project.clj
+++ b/project.clj
@@ -13,3 +13,4 @@
   :java-source-paths ["src"]
   :javac-options ["-target" "1.5" "-source" "1.5"]
   :jvm-opts ^:replace ["-server" "-Xmx500m" "-XX:NewSize=200m"])
+"compatibility "

--- a/src/clj_tuple.clj
+++ b/src/clj_tuple.clj
@@ -57,3 +57,5 @@
          (if (empty? s)
            (persistent! r)
            (recur (conj! r (first s)) (rest s)))))))
+
+(def ^:deprecated tuple #'vector)


### PR DESCRIPTION
I would like to upgrade to the latest version of tuple, but I have projects which have dependencies which use 0.1.7. Adding a deprecated tuple will fix the problem until the dependant libs catch up.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ztellman/clj-tuple/15)

<!-- Reviewable:end -->
